### PR TITLE
fix: remove @types/node from overrides to resolve EOVERRIDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,4 @@
   "patchedDependencies": {
     "@chat-adapter/telegram@4.20.0": "patches/@chat-adapter%2Ftelegram@4.20.0.patch"
   },
-  "overrides": {
-    "@types/node": "20.19.9"
-  }
 }


### PR DESCRIPTION
Remove the redundant `@types/node` entry from `overrides` — it conflicts with the direct devDependency and causes `npx @lobu/cli@latest` to fail with `EOVERRIDE` for all users running the CLI from the repo root.

Fixes #3